### PR TITLE
fix Sigin View Moving freely

### DIFF
--- a/LoginPopup.storyboard
+++ b/LoginPopup.storyboard
@@ -130,7 +130,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yFU-Jg-Xdh">
+                                        <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yFU-Jg-Xdh">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5lk-zZ-aGC">
@@ -341,7 +341,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VUM-VF-cqL">
+                                        <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VUM-VF-cqL">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="X3V-aN-shZ">


### PR DESCRIPTION
## What Being Fixed

    Fix the error that Sigin In View can move to anywhere freely.
    If you want to keep moving freely, change scroll enable to checked in scroll view inspector.